### PR TITLE
Use `plural` instead of `pluralize` with ModelName instance in `graph_da...

### DIFF
--- a/lib/rails_admin_charts.rb
+++ b/lib/rails_admin_charts.rb
@@ -20,7 +20,7 @@ module RailsAdminCharts
     def graph_data since=30.days.ago
       [
           {
-              name: model_name.pluralize,
+              name: model_name.plural,
               pointInterval: 1.day * 1000,
               pointStart: since.to_i * 1000,
               data: self.total_records_since(since)


### PR DESCRIPTION
Fixes Rails 4, rails_admin 0.5.0 'undefined method `pluralize' for #ActiveModel::Name:0x007f93a0175990'
