### PR TITLE
Don't pass hardcoded values

### DIFF
--- a/app/views/rails_admin/main/_chart.html.erb
+++ b/app/views/rails_admin/main/_chart.html.erb
@@ -66,10 +66,10 @@
                   series: [{
                     type: 'pie',
                     name: 'Number of <%= @abstract_model.to_s.pluralize %>',
-                    data: <%=raw @abstract_model.model.graph_data(100.days.ago).to_json %>
+                    data: <%=raw @abstract_model.model.graph_data.to_json %>
                   }],
                 <% else %>
-                  series: <%=raw @abstract_model.model.graph_data(100.days.ago).to_json %>,
+                  series: <%=raw @abstract_model.model.graph_data.to_json %>,
                 <% end %>
                 navigation: {
                     menuItemStyle: {


### PR DESCRIPTION
When I was trying to override the default value of since using 
def self.graph_data since=30.days.ago
    [
      {
          name: 'Admin Users',
          pointInterval: point_interval = 1.day \* 1000,
          pointStart: start_point = since.to_i \* 1000,
          data: self.where(type: 'Admin').delta_records_since(since)
      },
      {
          name: 'Standard Users',
          pointInterval: point_interval,
          pointStart: start_point,
          data: self.where(type: nil).delta_records_since(since)
      }
    ]
  end
The value is hardcoded as 100 in _chart.html.erb. Removing the hardcoded value from the view, the new default value would be 30.days.ago instead of 100.days.ago
